### PR TITLE
Instantiates AutomaticUpdateClass by the Interface AutomaticUpdates.

### DIFF
--- a/SebWindowsServiceWCF/ServiceImplementations/RegistryService.cs
+++ b/SebWindowsServiceWCF/ServiceImplementations/RegistryService.cs
@@ -176,7 +176,7 @@ namespace SebWindowsServiceWCF.ServiceImplementations
             //Use Automatic Update Class
             try
             {
-                var auc = new AutomaticUpdatesClass();
+                var auc = new AutomaticUpdates();
 
                 if (enable)
                     auc.Resume();


### PR DESCRIPTION
Instantiating by the concrete class leads to an error, because of the Attribute CoClass in AutomaticUpdates