### PR TITLE
Include all valid certificates in config tool

### DIFF
--- a/SebWindowsClient/SebWindowsClient/CryptographyUtils/SEBProtectionController.cs
+++ b/SebWindowsClient/SebWindowsClient/CryptographyUtils/SEBProtectionController.cs
@@ -148,10 +148,10 @@ namespace SebWindowsClient.CryptographyUtils
 
             X509Store store = new X509Store(StoreName.CertificateAuthority);
             store.Open(OpenFlags.ReadOnly);
-            X509Certificate2Collection certsCollection = store.Certificates.Find(X509FindType.FindByKeyUsage, (X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment), false);
+            X509Certificate2Collection certsCollection = store.Certificates.Find(X509FindType.FindByTimeValid, (DateTime.Now), false);
             store = new X509Store(StoreName.AddressBook);
             store.Open(OpenFlags.ReadOnly);
-            X509Certificate2Collection certsCollection2 = store.Certificates.Find(X509FindType.FindByKeyUsage, (X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment), false);
+            X509Certificate2Collection certsCollection2 = store.Certificates.Find(X509FindType.FindByTimeValid, (DateTime.Now), false);
             certsCollection.AddRange(certsCollection2);
 
             foreach (X509Certificate2 x509Certificate in certsCollection)

--- a/SebWindowsClient/SebWindowsClient/CryptographyUtils/SEBProtectionController.cs
+++ b/SebWindowsClient/SebWindowsClient/CryptographyUtils/SEBProtectionController.cs
@@ -148,10 +148,10 @@ namespace SebWindowsClient.CryptographyUtils
 
             X509Store store = new X509Store(StoreName.CertificateAuthority);
             store.Open(OpenFlags.ReadOnly);
-            X509Certificate2Collection certsCollection = store.Certificates.Find(X509FindType.FindByTimeValid, (DateTime.Now), false);
+            X509Certificate2Collection certsCollection = store.Certificates.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
             store = new X509Store(StoreName.AddressBook);
             store.Open(OpenFlags.ReadOnly);
-            X509Certificate2Collection certsCollection2 = store.Certificates.Find(X509FindType.FindByTimeValid, (DateTime.Now), false);
+            X509Certificate2Collection certsCollection2 = store.Certificates.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
             certsCollection.AddRange(certsCollection2);
 
             foreach (X509Certificate2 x509Certificate in certsCollection)


### PR DESCRIPTION
In the previous version, the GetSSLCertificatesAndNames method uses the FindByKeyUsage FindType to locate valid certs for SSL trust. This does not adequately allow all possible certificates which a system might use for SSL to be added to the configuration file. By changing to "FindByTimeValid," we instead list all currently-valid certificates on the system. This does put additional onus on the administrator to know which certificate is the appropriate certificate - but should reduce head-scratching when their certificate isn't listed.

See SourceForge support request https://sourceforge.net/p/seb/support-requests/55/ for background on the issue in my environment.