### PR TITLE
Added expansion of environment variables in getpermitted path.

### DIFF
--- a/SebWindowsClient/SebWindowsClient/SebWindowsClientForm.cs
+++ b/SebWindowsClient/SebWindowsClient/SebWindowsClientForm.cs
@@ -1341,6 +1341,10 @@ namespace SebWindowsClient
 				// But maybe the executable path is a relative path from the applications main directory to some subdirectory with the executable in it?
 				fullPath = path + executablePath + "\\" + executable;
 				if (File.Exists(fullPath)) return fullPath;
+
+				// Finally, the executable path could contain environment variables such as %AppData% which need to be expanded
+				fullPath = Environment.ExpandEnvironmentVariables(path) + "\\" + executable;
+				if (File.Exists(fullPath)) return fullPath;
 			}
 
 			// In the end we try to find the application using one of the system's standard paths + subdirectory path + executable


### PR DESCRIPTION
There are just two lines of code that will make life easier for a lot of people right now (i.e., those that need to remote proctor the exam through Zoom, Webex or similar tools that are indeed installed into %AppData% instead of the system path). 

If you're happy with that, please include it in a minor release quite quickly, the world needs it ;-)